### PR TITLE
Applies security settings to address findings from latest STIGs

### DIFF
--- a/ash-windows/stig/IE_11/stig.yml
+++ b/ash-windows/stig/IE_11/stig.yml
@@ -147,3 +147,15 @@
   policy_type: regpol
   value: '3'
   vtype: DWORD
+- key: Computer\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\EnableSSL3Fallback
+  policy_type: regpol
+  value: '0'
+  vtype: DWORD
+- key: Computer\Software\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\SecureProtocols
+  policy_type: regpol
+  value: '2560'
+  vtype: DWORD
+- key: Computer\Software\Microsoft\Windows\CurrentVersion\Policies\Ext\VersionCheckEnabled
+  policy_type: regpol
+  value: '1'
+  vtype: DWORD

--- a/ash-windows/stig/Windows_2008ServerR2_DC/stig_audit.csv
+++ b/ash-windows/stig/Windows_2008ServerR2_DC/stig_audit.csv
@@ -19,7 +19,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,RPC Events,{0CCE922E-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Authorization Policy Change,{0CCE9231-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Other Object Access Events,{0CCE9227-69AE-11D9-BED3-505054503030},No Auditing,,0
-,System,Account Lockout,{0CCE9217-69AE-11D9-BED3-505054503030},No Auditing,,0
+,System,Account Lockout,{0CCE9217-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Certification Services,{0CCE9221-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Network Policy Server,{0CCE9243-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,DPAPI Activity,{0CCE922D-69AE-11D9-BED3-505054503030},No Auditing,,0
@@ -42,7 +42,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Computer Account Management,{0CCE9236-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Logoff,{0CCE9216-69AE-11D9-BED3-505054503030},Success,,1
 ,System,Security Group Management,{0CCE9237-69AE-11D9-BED3-505054503030},Success and Failure,,3
-,System,Other System Events,{0CCE9214-69AE-11D9-BED3-505054503030},No Auditing,,0
+,System,Other System Events,{0CCE9214-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Process Termination,{0CCE922C-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Other Account Logon Events,{0CCE9241-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Non Sensitive Privilege Use,{0CCE9229-69AE-11D9-BED3-505054503030},No Auditing,,0

--- a/ash-windows/stig/Windows_2008ServerR2_MS/stig_audit.csv
+++ b/ash-windows/stig/Windows_2008ServerR2_MS/stig_audit.csv
@@ -19,7 +19,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,RPC Events,{0CCE922E-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Authorization Policy Change,{0CCE9231-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Other Object Access Events,{0CCE9227-69AE-11D9-BED3-505054503030},No Auditing,,0
-,System,Account Lockout,{0CCE9217-69AE-11D9-BED3-505054503030},No Auditing,,0
+,System,Account Lockout,{0CCE9217-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Certification Services,{0CCE9221-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Network Policy Server,{0CCE9243-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,DPAPI Activity,{0CCE922D-69AE-11D9-BED3-505054503030},No Auditing,,0
@@ -42,7 +42,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Computer Account Management,{0CCE9236-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Logoff,{0CCE9216-69AE-11D9-BED3-505054503030},Success,,1
 ,System,Security Group Management,{0CCE9237-69AE-11D9-BED3-505054503030},Success and Failure,,3
-,System,Other System Events,{0CCE9214-69AE-11D9-BED3-505054503030},No Auditing,,0
+,System,Other System Events,{0CCE9214-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Process Termination,{0CCE922C-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Other Account Logon Events,{0CCE9241-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Non Sensitive Privilege Use,{0CCE9229-69AE-11D9-BED3-505054503030},No Auditing,,0

--- a/ash-windows/stig/Windows_2012ServerR2_DC/stig.yml
+++ b/ash-windows/stig/Windows_2012ServerR2_DC/stig.yml
@@ -471,7 +471,7 @@
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\System\EnableSmartScreen
   policy_type: regpol
-  value: '0'
+  value: '2'
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\LocationAndSensors\DisableLocation
   policy_type: regpol
@@ -566,13 +566,17 @@
   policy_type: regpol
   value: '255'
   vtype: DWORD
+- key: Computer\Software\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled
+  policy_type: regpol
+  value: '1'
+  vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\EventLog\Application\MaxSize
   policy_type: regpol
   value: '32768'
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\EventLog\Security\MaxSize
   policy_type: regpol
-  value: '81920'
+  value: '196608'
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\EventLog\System\MaxSize
   policy_type: regpol

--- a/ash-windows/stig/Windows_2012ServerR2_DC/stig_audit.csv
+++ b/ash-windows/stig/Windows_2012ServerR2_DC/stig_audit.csv
@@ -7,7 +7,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Audit Process Creation,{0cce922b-69ae-11d9-bed3-505054503030},Success,,1
 ,System,Audit Directory Service Access,{0cce923b-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Directory Service Changes,{0cce923c-69ae-11d9-bed3-505054503030},Success and Failure,,3
-,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success,,1
+,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Logoff,{0cce9216-69ae-11d9-bed3-505054503030},Success,,1
 ,System,Audit Logon,{0cce9215-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Special Logon,{0cce921b-69ae-11d9-bed3-505054503030},Success,,1

--- a/ash-windows/stig/Windows_2012ServerR2_MS/stig.yml
+++ b/ash-windows/stig/Windows_2012ServerR2_MS/stig.yml
@@ -467,7 +467,7 @@
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\System\EnableSmartScreen
   policy_type: regpol
-  value: '0'
+  value: '2'
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\LocationAndSensors\DisableLocation
   policy_type: regpol
@@ -562,13 +562,17 @@
   policy_type: regpol
   value: '255'
   vtype: DWORD
+- key: Computer\Software\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled
+  policy_type: regpol
+  value: '1'
+  vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\EventLog\Application\MaxSize
   policy_type: regpol
   value: '32768'
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\EventLog\Security\MaxSize
   policy_type: regpol
-  value: '81920'
+  value: '196608'
   vtype: DWORD
 - key: Computer\Software\Policies\Microsoft\Windows\EventLog\System\MaxSize
   policy_type: regpol

--- a/ash-windows/stig/Windows_2012ServerR2_MS/stig_audit.csv
+++ b/ash-windows/stig/Windows_2012ServerR2_MS/stig_audit.csv
@@ -5,7 +5,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Audit Security Group Management,{0cce9237-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit User Account Management,{0cce9235-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Process Creation,{0cce922b-69ae-11d9-bed3-505054503030},Success,,1
-,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success,,1
+,System,Audit Account Lockout,{0cce9217-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Logoff,{0cce9216-69ae-11d9-bed3-505054503030},Success,,1
 ,System,Audit Logon,{0cce9215-69ae-11d9-bed3-505054503030},Success and Failure,,3
 ,System,Audit Special Logon,{0cce921b-69ae-11d9-bed3-505054503030},Success,,1

--- a/ash-windows/stig/Windows_2016Server_DC/stig.yml
+++ b/ash-windows/stig/Windows_2016Server_DC/stig.yml
@@ -97,3 +97,15 @@
 - name: SeDenyBatchLogonRight
   policy_type: secedit
   value: '*S-1-5-32-546'
+  - key: Computer\System\CurrentControlSet\Services\mrxsmb10\Start
+  policy_type: regpol
+  value: '4'
+  vtype: DWORD
+- key: Computer\System\CurrentControlSet\Services\LanmanServer\Parameters\SMB1
+  policy_type: regpol
+  value: '0'
+  vtype: DWORD
+- key: Computer\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled
+  policy_type: regpol
+  value: '1'
+  vtype: DWORD

--- a/ash-windows/stig/Windows_2016Server_MS/stig.yml
+++ b/ash-windows/stig/Windows_2016Server_MS/stig.yml
@@ -98,3 +98,15 @@
 - name: SeDenyBatchLogonRight
   policy_type: secedit
   value: '*S-1-5-32-546'
+- key: Computer\System\CurrentControlSet\Services\mrxsmb10\Start
+  policy_type: regpol
+  value: '4'
+  vtype: DWORD
+- key: Computer\System\CurrentControlSet\Services\LanmanServer\Parameters\SMB1
+  policy_type: regpol
+  value: '0'
+  vtype: DWORD
+- key: Computer\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\Audit\ProcessCreationIncludeCmdLine_Enabled
+  policy_type: regpol
+  value: '1'
+  vtype: DWORD


### PR DESCRIPTION
- OS scans for Win16, Win12r2, Win08r2 return 100% compliance
- For IE11, there is a new STIG setting to disable TLS1.0 (DTBI014-IE11-TLS setting). IAVM baseline still has setting to use TLS1.0. Since IAVM overrides STIG baseline, the IE scan will show the finding.