### PR TITLE
Updates Formula to Support Salt 2017.7.x and 2018.3.x

### DIFF
--- a/ash-windows/custom/init.sls
+++ b/ash-windows/custom/init.sls
@@ -10,7 +10,7 @@ Create Custom Log Directory:
 
 Apply Custom Local Group Policy Objects:
   lgpo.present:
-    - policies: {{ custom.custom_policies }}
+    - policies: {{ custom.custom_policies | yaml }}
     - logfile: {{ custom.logdir }}\custom-policies.log
     - errorfile: {{ custom.logdir }}\custom-policies.err
     - require:

--- a/ash-windows/delta/delta.yml
+++ b/ash-windows/delta/delta.yml
@@ -1,9 +1,6 @@
 - name: NewGuestName
   policy_type: secedit
   value: '"xGuest"'
-- name: NewAdministratorName
-  policy_type: secedit
-  value: '"xAdministrator"'
 - name: SeDenyRemoteInteractiveLogonRight
   policy_type: secedit
   value: '*S-1-5-32-546'

--- a/ash-windows/delta/init.sls
+++ b/ash-windows/delta/init.sls
@@ -10,7 +10,7 @@ Create Delta Log Directory:
 
 Apply Delta Local Group Policy Objects:
   lgpo.present:
-    - policies: {{ delta.delta_policies }}
+    - policies: {{ delta.delta_policies | yaml }}
     - logfile: {{ delta.logdir }}\delta-policies.log
     - errorfile: {{ delta.logdir }}\delta-policies.err
     - require:

--- a/ash-windows/iavm/init.sls
+++ b/ash-windows/iavm/init.sls
@@ -10,7 +10,7 @@ Create IAVM Log Directory:
 
 Apply IAVM Local Group Policy Objects:
   lgpo.present:
-    - policies: {{ iavm.iavm_policies }}
+    - policies: {{ iavm.iavm_policies | yaml }}
     - logfile: {{ iavm.logdir }}\iavm-policies.log
     - errorfile: {{ iavm.logdir }}\iavm-policies.err
     - require:

--- a/ash-windows/scm/init.sls
+++ b/ash-windows/scm/init.sls
@@ -12,7 +12,7 @@ Create SCM Log Directory:
 
 Apply Security Template:
   lgpo.present:
-    - policies: {{ scm.gpttmpl_policies }}
+    - policies: {{ scm.gpttmpl_policies | yaml }}
     - logfile: {{ scm.logdir }}\scm-{{ scm.os_path }}-GptTmpl.log
     - errorfile: {{ scm.logdir }}\scm-{{ scm.os_path }}-GptTmpl.err
     - require:
@@ -20,7 +20,7 @@ Apply Security Template:
 
 Apply Computer Configuration:
   lgpo.present:
-    - policies: {{ scm.computer_policies }}
+    - policies: {{ scm.computer_policies | yaml }}
     - logfile: {{ scm.logdir }}\scm-{{ scm.os_path }}-MachineSettings.log
     - errorfile: {{ scm.logdir }}\scm-{{ scm.os_path }}-MachineSettings.err
     - require:
@@ -28,7 +28,7 @@ Apply Computer Configuration:
 
 Apply User Configuration:
   lgpo.present:
-    - policies: {{ scm.user_policies }}
+    - policies: {{ scm.user_policies | yaml}}
     - logfile: {{ scm.logdir }}\scm-{{ scm.os_path }}-UserSettings.log
     - errorfile: {{ scm.logdir }}\scm-{{ scm.os_path }}-UserSettings.err
     - require:
@@ -36,7 +36,7 @@ Apply User Configuration:
 
 Apply Internet Explorer Machine Policy:
   lgpo.present:
-    - policies: {{ scm.ie_computer_policies }}
+    - policies: {{ scm.ie_computer_policies | yaml}}
     - logfile: {{ scm.logdir }}\scm-{{ scm.ie_path }}-MachineSettings.log
     - errorfile: {{ scm.logdir }}\scm-{{ scm.ie_path }}-MachineSettings.err
     - require:
@@ -44,7 +44,7 @@ Apply Internet Explorer Machine Policy:
 
 Apply Internet Explorer User Policy:
   lgpo.present:
-    - policies: {{ scm.ie_user_policies }}
+    - policies: {{ scm.ie_user_policies | yaml }}
     - logfile: {{ scm.logdir }}\scm-{{ scm.ie_path }}-UserSettings.log
     - errorfile: {{ scm.logdir }}\scm-{{ scm.ie_path }}-UserSettings.err
     - require:

--- a/ash-windows/stig/init.sls
+++ b/ash-windows/stig/init.sls
@@ -13,7 +13,7 @@ Create STIG Log Directory:
 
 Apply STIG Local Group Policy Objects:
   lgpo.present:
-    - policies: {{ stig.stig_policies }}
+    - policies: {{ stig.stig_policies | yaml }}
     - logfile: {{ stig.logdir }}\stig-{{ stig.os_path }}-MachineSettings.log
     - errorfile: {{ stig.logdir }}\stig-{{ stig.os_path }}-MachineSettings.err
     - require:
@@ -21,7 +21,7 @@ Apply STIG Local Group Policy Objects:
 
 Apply IE STIG Local Group Policy Objects:
   lgpo.present:
-    - policies: {{ stig.ie_stig_policies }}
+    - policies: {{ stig.ie_stig_policies | yaml }}
     - logfile: {{ stig.logdir }}\stig-{{ stig.ie_path }}-MachineSettings.log
     - errorfile: {{ stig.logdir }}\stig-{{ stig.ie_path }}-MachineSettings.err
     - require:


### PR DESCRIPTION
These modifications fix some unicode parsing errors and address warnings related to depricated Salt modules.  There are still additional errors to resolve when using Salt 2017.7.7 and 2018.3.2.

However, Watchmaker completes successfully with these modifications when using Salt 2016.6.6 on Windows.