### PR TITLE
CIS 1.3.0 Additions

### DIFF
--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
@@ -44,7 +44,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Filtering Platform Policy Change,{0CCE9233-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Authorization Policy Change,{0CCE9231-69AE-11D9-BED3-505054503030},Success,,1
 ,System,MPSSVC Rule-Level Policy Change,{0CCE9232-69AE-11D9-BED3-505054503030},Success and Failure,,3
-,System,Other Account Management Events,{0CCE923A-69AE-11D9-BED3-505054503030},No Auditing,,0
+,System,Other Account Management Events,{0CCE923A-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Application Group Management,{0CCE9239-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Distribution Group Management,{0CCE9238-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Security Group Management,{0CCE9237-69AE-11D9-BED3-505054503030},Success,,1

--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
@@ -1,7 +1,7 @@
 Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclusion Setting,Setting Value
 ,System,IPsec Driver,{0CCE9213-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,System Integrity,{0CCE9212-69AE-11D9-BED3-505054503030},Success and Failure,,3
-,System,Security System Extension,{0CCE9211-69AE-11D9-BED3-505054503030},Success,,1
+,System,Security System Extension,{0CCE9211-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Security State Change,{0CCE9210-69AE-11D9-BED3-505054503030},Success,,1
 ,System,Other System Events,{0CCE9214-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Group Membership,{0CCE9249-69AE-11D9-BED3-505054503030},Success,,1

--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
@@ -47,7 +47,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Other Account Management Events,{0CCE923A-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Application Group Management,{0CCE9239-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Distribution Group Management,{0CCE9238-69AE-11D9-BED3-505054503030},No Auditing,,0
-,System,Security Group Management,{0CCE9237-69AE-11D9-BED3-505054503030},Success,,1
+,System,Security Group Management,{0CCE9237-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Computer Account Management,{0CCE9236-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,User Account Management,{0CCE9235-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Directory Service Replication,{0CCE923D-69AE-11D9-BED3-505054503030},No Auditing,,0

--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
@@ -40,7 +40,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,DPAPI Activity,{0CCE922D-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Other Policy Change Events,{0CCE9234-69AE-11D9-BED3-505054503030},Failure,,2
 ,System,Authentication Policy Change,{0CCE9230-69AE-11D9-BED3-505054503030},Success,,1
-,System,Audit Policy Change,{0CCE922F-69AE-11D9-BED3-505054503030},Success,,1
+,System,Audit Policy Change,{0CCE922F-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Filtering Platform Policy Change,{0CCE9233-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Authorization Policy Change,{0CCE9231-69AE-11D9-BED3-505054503030},Success,,1
 ,System,MPSSVC Rule-Level Policy Change,{0CCE9232-69AE-11D9-BED3-505054503030},Success and Failure,,3

--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
@@ -12,7 +12,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,IPsec Extended Mode,{0CCE921A-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,IPsec Quick Mode,{0CCE9219-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,IPsec Main Mode,{0CCE9218-69AE-11D9-BED3-505054503030},No Auditing,,0
-,System,Account Lockout,{0CCE9217-69AE-11D9-BED3-505054503030},Failure,,2
+,System,Account Lockout,{0CCE9217-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Logoff,{0CCE9216-69AE-11D9-BED3-505054503030},Success,,1
 ,System,Logon,{0CCE9215-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Handle Manipulation,{0CCE9223-69AE-11D9-BED3-505054503030},No Auditing,,0

--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/audit.csv
@@ -48,7 +48,7 @@ Machine Name,Policy Target,Subcategory,Subcategory GUID,Inclusion Setting,Exclus
 ,System,Application Group Management,{0CCE9239-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Distribution Group Management,{0CCE9238-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Security Group Management,{0CCE9237-69AE-11D9-BED3-505054503030},Success,,1
-,System,Computer Account Management,{0CCE9236-69AE-11D9-BED3-505054503030},No Auditing,,0
+,System,Computer Account Management,{0CCE9236-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,User Account Management,{0CCE9235-69AE-11D9-BED3-505054503030},Success and Failure,,3
 ,System,Directory Service Replication,{0CCE923D-69AE-11D9-BED3-505054503030},No Auditing,,0
 ,System,Directory Service Access,{0CCE923B-69AE-11D9-BED3-505054503030},No Auditing,,0

--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/cis_1_3_0.yml
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/cis_1_3_0.yml
@@ -77,6 +77,11 @@
   value: '0'
   vtype: DWORD
 
+- key: Computer\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\NoConnectedUser
+  policy_type: regpol
+  value: '3'
+  vtype: DWORD
+
 - key: Computer\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon
   policy_type: regpol
   value: '0'

--- a/ash-windows/cis_1_3_0/Windows_2016Server_MS/cis_1_3_0.yml
+++ b/ash-windows/cis_1_3_0/Windows_2016Server_MS/cis_1_3_0.yml
@@ -82,6 +82,11 @@
   value: '3'
   vtype: DWORD
 
+- key: Computer\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System\dontdisplaylastusername
+  policy_type: regpol
+  value: '1'
+  vtype: DWORD
+
 - key: Computer\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon\AutoAdminLogon
   policy_type: regpol
   value: '0'


### PR DESCRIPTION
This content builds on the prior PR (#61), adding hardenings for:
* finding 2.3.4.1
* finding 2.3.1.2
* finding 17.2.5
* finding 17.2.4
* finding 17.2.2
* finding 17.5.1
* finding 17.7.1
* finding 17.9.4

Note 1: These findings are not addressed in the official AMIs from CIS but Inspector flags them. Applying them doesn't really improve security-posture, just reduce number of Inspector findings

Note 2: The CIS benchmarks do caveat the auditing-related findings (17.X.Y) as follows:

> if audit settings are too severe, critically important entries in the Security log may be obscured by all of the meaningless entries and computer performance and the available amount of data storage may be seriously affected.

As the 17.X.Ys were added _after_ the 2.3.X.Ys, rolling back to d4a3df33dfc77cc3d9c4cb282b027007e62c3fec would be a quick way to avoid their potential adverse impacts